### PR TITLE
Add comprehensive Content-Type handling for common file types in router

### DIFF
--- a/webview/WebViewToo.ahk
+++ b/webview/WebViewToo.ahk
@@ -655,14 +655,14 @@ class WebViewCtrl extends Gui.Custom {
     _Router(ICoreWebView2, Args) {
         Parsed := WebViewCtrl.ParseUri(Args.Request.Uri)
         Path := Parsed.Path, Host := Parsed.host
-		
+        
         Target := unset
         CompiledRoutes := this._CompiledRoutes[Host]
         RegExMatch(Path, CompiledRoutes.Pattern)
         if (!IsSet(Target)) {
             return
         }
-		
+        
         if (Target is Object && !(Target is Buffer)) {
             try Target := Target(Parsed)
         }
@@ -675,8 +675,17 @@ class WebViewCtrl extends Gui.Custom {
 
         if (Target is String) {
             Headers := ""
-            if (Path ~= "i)\.js$") {
-                Headers .= "Content-Type: text/javascript;"
+            if (RegExMatch(Path, "i)\.([a-z0-9]+)$", &m)) {
+                ext := StrLower(m[1])
+                if (ext = "js" || ext = "mjs") {
+                    Headers .= "Content-Type: text/javascript;"
+                } else if (ext = "css") {
+                    Headers .= "Content-Type: text/css;"
+                } else if (ext = "html" || ext = "htm") {
+                    Headers .= "Content-Type: text/html;"
+                } else if (ext = "json" || ext = "map") {
+                    Headers .= "Content-Type: application/json;"
+                }
             }
             Stream := WebView2.CreateTextStream(Target)
             Args.Response := ICoreWebView2.Environment.CreateWebResourceResponse(Stream, 200, "OK", Headers)
@@ -685,12 +694,59 @@ class WebViewCtrl extends Gui.Custom {
 
         if (Target is WebView2.Stream) {
             Headers := ""
-			if(RegExMatch(Args.Request.Uri, "i)\.js$")) {
-				Headers .= "Content-Type: text/javascript;"
-			}
-			if(RegExMatch(Args.Request.Uri, "i)\.svg$")) {
-				Headers .= "Content-Type: image/svg+xml;"
-			}
+            ; Determine content type from requested path (ignore querystring)
+            if (RegExMatch(Path, "i)\.([a-z0-9]+)$", &m)) {
+                ext := StrLower(m[1])
+                if (ext = "js" || ext = "mjs") {
+                    Headers .= "Content-Type: text/javascript;"
+                } else if (ext = "css") {
+                    Headers .= "Content-Type: text/css;"
+                } else if (ext = "html" || ext = "htm") {
+                    Headers .= "Content-Type: text/html;"
+                } else if (ext = "svg") {
+                    Headers .= "Content-Type: image/svg+xml;"
+                } else if (ext = "png") {
+                    Headers .= "Content-Type: image/png;"
+                } else if (ext = "jpg" || ext = "jpeg") {
+                    Headers .= "Content-Type: image/jpeg;"
+                } else if (ext = "gif") {
+                    Headers .= "Content-Type: image/gif;"
+                } else if (ext = "webp") {
+                    Headers .= "Content-Type: image/webp;"
+                } else if (ext = "ico") {
+                    Headers .= "Content-Type: image/x-icon;"
+                } else if (ext = "json" || ext = "map") {
+                    Headers .= "Content-Type: application/json;"
+                } else if (ext = "wasm") {
+                    Headers .= "Content-Type: application/wasm;"
+                } else if (ext = "pdf") {
+                    Headers .= "Content-Type: application/pdf;"
+                } else if (ext = "txt" || ext = "log") {
+                    Headers .= "Content-Type: text/plain;"
+                } else if (ext = "xml") {
+                    Headers .= "Content-Type: application/xml;"
+                } else if (ext = "csv") {
+                    Headers .= "Content-Type: text/csv;"
+                } else if (ext = "mp3") {
+                    Headers .= "Content-Type: audio/mpeg;"
+                } else if (ext = "wav") {
+                    Headers .= "Content-Type: audio/wav;"
+                } else if (ext = "ogg" || ext = "oga") {
+                    Headers .= "Content-Type: audio/ogg;"
+                } else if (ext = "mp4") {
+                    Headers .= "Content-Type: video/mp4;"
+                } else if (ext = "webm") {
+                    Headers .= "Content-Type: video/webm;"
+                } else if (ext = "woff") {
+                    Headers .= "Content-Type: font/woff;"
+                } else if (ext = "woff2") {
+                    Headers .= "Content-Type: font/woff2;"
+                } else if (ext = "ttf") {
+                    Headers .= "Content-Type: font/ttf;"
+                } else if (ext = "otf") {
+                    Headers .= "Content-Type: font/otf;"
+                }
+            }
             Args.Response := ICoreWebView2.Environment.CreateWebResourceResponse(Target, 200, "OK", Headers)
             return
         }
@@ -826,10 +882,10 @@ class WebViewCtrl extends Gui.Custom {
         this.OpenDevToolsWindow()
     }
 
-	DragParentWindow() {
-    	DllCall("ReleaseCapture")
-    	AncestorHwnd := DllCall("GetAncestor", "Int", this.Hwnd, "Int", GA_ROOT := 2)
-    	PostMessage(0x00A1, 2, 0,, AncestorHwnd) ;WM_NCLBUTTONDOWN
+    DragParentWindow() {
+        DllCall("ReleaseCapture")
+        AncestorHwnd := DllCall("GetAncestor", "Int", this.Hwnd, "Int", GA_ROOT := 2)
+        PostMessage(0x00A1, 2, 0,, AncestorHwnd) ;WM_NCLBUTTONDOWN
     }
     IsParentWindowDraggingEnabled {
         get => this._IsParentWindowDraggingEnabled


### PR DESCRIPTION
### Summary
This PR improves static asset handling in the WebView2 request router by adding Content-Type headers for a broad set of common file extensions.

### Details
- Adds logic to detect resource file extension and set the appropriate Content-Type header for common types (js, css, html, images, audio, video, fonts, etc.) when responding with WebView2.Stream.
- Ensures string-based resource responses also include the correct Content-Type for JavaScript, CSS, HTML, and JSON.
- Addresses browser compatibility and security concerns related to missing MIME types in asset responses.
