### PR TITLE
feat(anime4x): add scale support and shared processing path for Anime4xRun and AnimePolishRun

### DIFF
--- a/anime4x.ahk
+++ b/anime4x.ahk
@@ -15,7 +15,7 @@ Class anime4x
 		this.outputfile := outputfile
 	}
 
-	static go() {
+	static go(scale := 1) {
 		if not FileExist(this.inputfile) {
 			return
 		}
@@ -26,6 +26,27 @@ Class anime4x
 		if result != 0 {
 			return result
 		}
+
+		if (scale < 1) {
+			pBitmap := Gdip_CreateBitmapFromFile(this.outputfile)
+			Width := Gdip_GetImageWidth(pBitmap)
+			Height := Gdip_GetImageHeight(pBitmap)
+
+			NewWidth := Round(Width * scale)
+			NewHeight := Round(Height * scale)
+
+			pBitmapNew := Gdip_CreateBitmap(NewWidth, NewHeight)
+			G := Gdip_GraphicsFromImage(pBitmapNew)
+			Gdip_SetInterpolationMode(G, 7)
+			Gdip_DrawImage(G, pBitmap, 0, 0, NewWidth, NewHeight, 0, 0, Width, Height)
+			Gdip_DisposeImage(pBitmap)
+			Gdip_DeleteGraphics(G)
+
+			FileDelete this.outputfile
+			Gdip_SaveBitmapToFile(pBitmapNew, this.outputfile)
+			Gdip_DisposeImage(pBitmapNew)
+		}
+
 		; this.output_bitmap := Gdip_CreateBitmapFromFile(this.outputfile)
 		Gdip_DisposeImage(this.input_bitmap)
 		EncodedString := FileToBase64(anime4x.outputfile)
@@ -50,62 +71,62 @@ Class anime4x
 ; =================================================================
 FileToBase64(FilePath)
 {
-    local Stream, XML, Node, BinaryData, Base64Str
-    
-    ; 1. Read the binary file data using ADODB.Stream
-    Stream := ComObject("ADODB.Stream")
-    if !IsObject(Stream)
-    {
-        ErrorLevel := 1 ; COM object creation failed
-        return ""
-    }
-    
-    Stream.Type := 1 ; 1 = adTypeBinary
-    Stream.Open
-    
-    ; Try to load the file into the stream
-    try
-    {
-        Stream.LoadFromFile(FilePath)
-        Stream.Position := 0 ; Rewind to the beginning
-    }
-    catch
-    {
-        ErrorLevel := 2 ; Failed to load file
-        Stream.Close()
-        return ""
-    }
+	local Stream, XML, Node, BinaryData, Base64Str
 
-    ; Get the binary data from the stream
-    BinaryData := Stream.Read(-1) ; -1 = adReadAll
-    Stream.Close()
-    
-    ; 2. Use MSXML2.DOMDocument for Base64 Encoding
-    XML := ComObject("MSXML2.DOMDocument")
-    if !IsObject(XML)
-    {
-        ErrorLevel := 3 ; COM object creation failed
-        return ""
-    }
-    
-    ; Create a temporary XML node to hold the binary data
-    Node := XML.createElement("Base64Data")
-    
-    ; Append the binary data directly to the node (this is where the encoding happens)
-    try
-    {
-        Node.dataType := "bin.base64"
-        Node.nodeTypedValue := BinaryData
-    }
-    catch
-    {
-        ErrorLevel := 4 ; Encoding failed
-        return ""
-    }
-    
-    ; Extract the text content, which is the Base64 string
-    Base64Str := Node.text
-    
-    ErrorLevel := 0
-    return Base64Str
+	; 1. Read the binary file data using ADODB.Stream
+	Stream := ComObject("ADODB.Stream")
+	if !IsObject(Stream)
+	{
+		ErrorLevel := 1 ; COM object creation failed
+		return ""
+	}
+
+	Stream.Type := 1 ; 1 = adTypeBinary
+	Stream.Open
+
+	; Try to load the file into the stream
+	try
+	{
+		Stream.LoadFromFile(FilePath)
+		Stream.Position := 0 ; Rewind to the beginning
+	}
+	catch
+	{
+		ErrorLevel := 2 ; Failed to load file
+		Stream.Close()
+		return ""
+	}
+
+	; Get the binary data from the stream
+	BinaryData := Stream.Read(-1) ; -1 = adReadAll
+	Stream.Close()
+
+	; 2. Use MSXML2.DOMDocument for Base64 Encoding
+	XML := ComObject("MSXML2.DOMDocument")
+	if !IsObject(XML)
+	{
+		ErrorLevel := 3 ; COM object creation failed
+		return ""
+	}
+
+	; Create a temporary XML node to hold the binary data
+	Node := XML.createElement("Base64Data")
+
+	; Append the binary data directly to the node (this is where the encoding happens)
+	try
+	{
+		Node.dataType := "bin.base64"
+		Node.nodeTypedValue := BinaryData
+	}
+	catch
+	{
+		ErrorLevel := 4 ; Encoding failed
+		return ""
+	}
+
+	; Extract the text content, which is the Base64 string
+	Base64Str := Node.text
+
+	ErrorLevel := 0
+	return Base64Str
 }

--- a/app.ahk
+++ b/app.ahk
@@ -1,4 +1,3 @@
-﻿
 SetWorkingDir(A_ScriptDir)
 #SingleInstance force
 #include meta.ahk
@@ -32,17 +31,17 @@ scriptBusy := false
 WebViewSettings := {}
 if (A_IsCompiled) {
 	WebViewCtrl.CreateFileFromResource("64bit\WebView2Loader.dll", WebViewCtrl.TempDir)
-    WebViewSettings := {DllPath: WebViewCtrl.TempDir "\64bit\WebView2Loader.dll"}
+	WebViewSettings := { DllPath: WebViewCtrl.TempDir "\64bit\WebView2Loader.dll" }
 }
 
-MyGui := WebViewGui("+Resize +MinSize800x600",,, WebViewSettings)
+MyGui := WebViewGui("+Resize +MinSize800x600", , , WebViewSettings)
 MyGui.OnEvent("Close", mygui_Close)
 
 MyGui.AddCallbackToScript("Visit", WebviewVisit)
 MyGui.AddCallbackToScript("anime4x", Anime4xRun)
 MyGui.AddCallbackToScript("animePolish", AnimePolishRun)
 
-if(A_IsCompiled) {
+if (A_IsCompiled) {
 	MyGui.Navigate("index.html")
 } else {
 	MyGui.Navigate("http://localhost:5173")
@@ -51,15 +50,19 @@ if(A_IsCompiled) {
 MyGui.Show("w820 h600")
 Return
 
-pushMsg(type, code, content:="") {
+pushMsg(type, code, content := "") {
 	MyGui.PostWebMessageAsJson('{"type":"' type '","code":' code ',"content":"' content '"}')
 }
 
 AnimePolishRun(webview, base64) {
-
+	RunAnimeProcessing(webview, base64, 0.25)
 }
 Anime4xRun(webview, base64) {
-	if(scriptBusy) {
+	RunAnimeProcessing(webview, base64, 1)
+}
+
+RunAnimeProcessing(webview, base64, scale) {
+	if (scriptBusy) {
 		pushMsg("state", 2)
 		Return
 	}
@@ -70,22 +73,22 @@ Anime4xRun(webview, base64) {
 		if FileExist(A_Temp '\CYKSM\temp_output.png') {
 			FileDelete(A_Temp '\CYKSM\temp_output.png')
 		}
-		
+
 		base64 := RegExReplace(base64, "(?i)^.*?base64,")
 		pBitmap := Gdip_BitmapFromBase64(&base64)
 		input_error := Gdip_SaveBitmapToFile(pBitmap, A_Temp '\CYKSM\temp_input.png')
-		if(input_error < 0) {
+		if (input_error < 0) {
 			pushMsg("error", input_error, "GDIp save bitmap to file failed")
 			return
 		}
-		
+
 		anime4x.inputpath(A_Temp '\CYKSM\temp_input.png')
 		anime4x.outputpath(A_Temp '\CYKSM\temp_output.png')
 		pushMsg("state", 1)
 		global scriptBusy := true
-		result := anime4x.go()
+		result := anime4x.go(scale)
 		scriptBusy := false
-		if(result == 0) {
+		if (result == 0) {
 			pushMsg("result", result, anime4x.output_base64)
 		} else {
 			pushMsg("error", result, "realesrgan error")
@@ -101,7 +104,7 @@ WebviewVisit(webview, msg) {
 mygui_Close(*) {
 	trueExit(0, 0)
 }
-trueExit(ExitReason, ExitCode){
+trueExit(ExitReason, ExitCode) {
 	ExitApp
 }
 
@@ -114,5 +117,5 @@ trueExit(ExitReason, ExitCode){
 
 ;@Ahk2Exe-IgnoreBegin
 ; For dev
-F6::ExitApp(5173)
+F6:: ExitApp(5173)
 ;@Ahk2Exe-IgnoreEnd


### PR DESCRIPTION
### Summary
This PR adds a scale parameter to the anime4x pipeline to downscale output when scale is less than 1, finishes AnimePolishRun to use the same processing path as Anime4xRun at 0.25 scale, and introduces a shared RunAnimeProcessing function to improve readability and consistency.

### Details
- Implement scale-aware go(scale) in anime4x.ahk to downscale output with GDI+ when scale < 1
- Introduce RunAnimeProcessing(webview, base64, scale) in app.ahk to centralize input decoding, model invocation, and result encoding
- Update AnimePolishRun to call RunAnimeProcessing with scale 0.25
- Update Anime4xRun to call RunAnimeProcessing with scale 1
- Pass scale through to the underlying anime4x.go(scale) call
- Return the output as a base64 data URI for UI consumption
- No breaking changes; behavior is additive

Warning: [Task VM test](https://cto.new/account/workspace/repositories/cac1e4ef-7930-4804-bd74-478c81918ba9/virtual-machine) is not passing, cto.new will perform much better if you fix the setup