### PR TITLE
feat(frontend): add DaisyUI-based toast notifications with showMessage and enable pending calls

### DIFF
--- a/frontend/components/user_input.html
+++ b/frontend/components/user_input.html
@@ -4,7 +4,7 @@
 		// validate the preview.src is valid base64
 		const base64Regex = /^data:image\/(?:jpeg|png|webp);base64/
 		if (!base64Regex.test(inputPreview.src)) {
-			// showMessage("Please select an image first.", "error")
+			window.showMessage("Please select an image first.", "error")
 			return
 		}
 		const scale = document.getElementById("keep-res").checked ? 0.25 : 1

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -84,10 +84,10 @@
 			ALLOWED_MIMES.includes(f.type)
 		)
 		if (!file) {
-			// showMessage(
-			// 	"File rejected: Please select a JPEG, PNG, or WebP image.",
-			// 	"error"
-			// )
+			window.showMessage(
+				"File rejected: Please select a JPEG, PNG, or WebP image.",
+				"error"
+			)
 			return
 		}
 		const reader = new FileReader()
@@ -126,6 +126,40 @@
 		window.setPictureOnDiv("output-preview", source)
 		window.setMainState("done")
 	}
+	window.showMessage = function (message, type = "info") {
+		let container = document.getElementById("toast-container")
+		if (!container) {
+			container = document.createElement("div")
+			container.id = "toast-container"
+			container.className = "toast toast-top toast-end z-50"
+			document.body.appendChild(container)
+		}
+
+		const alertDiv = document.createElement("div")
+		const alertClass =
+			type === "error"
+				? "alert-error"
+				: type === "success"
+				? "alert-success"
+				: type === "warning"
+				? "alert-warning"
+				: "alert-info"
+		alertDiv.className = `alert ${alertClass}`
+
+		const span = document.createElement("span")
+		span.textContent = message
+		alertDiv.appendChild(span)
+
+		container.appendChild(alertDiv)
+
+		setTimeout(() => {
+			alertDiv.remove()
+			if (container.children.length === 0) {
+				container.remove()
+			}
+		}, 3000)
+	}
+
 	window.setMainState = function (next) {
 		// idle -> ready -> processing -> done
 		// error -> idle
@@ -145,7 +179,7 @@
 				filePicker.value = null
 				inputResolution.textContent = ""
 				outputResolution.textContent = ""
-				
+
 				startBtn.classList.add("btn-disabled")
 				startBtn.setAttribute("data-i18n", "start")
 				window.i18n.updateElement(startBtn)
@@ -181,6 +215,13 @@ function onMsg(Msg) {
 					window.setOutputImage(Msg.data.content)
 					window.setMainState("done")
 				}
+				break
+			case "error":
+				window.showMessage(
+					`Error ${Msg.data.code}: ${Msg.data.content}`,
+					"error"
+				)
+				window.setMainState("idle")
 				break
 		}
 	}


### PR DESCRIPTION
### Summary
This PR adds a DaisyUI-based toast notification system and enables all previously commented showMessage invocations across the frontend. It enhances user feedback during file selection and runtime errors.

### Details
- Implemented window.showMessage in frontend/src/main.js to render DaisyUI toast alerts.
- Replaced commented showMessage calls in user_input.html and main.js to actually show messages (invalid file, etc.).
- Wire error messages from backend (onMsg) to display via toast.
- Automatically creates and cleans up toast container.
- No API changes; purely UI feedback improvements.

Warning: [Task VM test](https://cto.new/account/workspace/repositories/cac1e4ef-7930-4804-bd74-478c81918ba9/virtual-machine) is not passing, cto.new will perform much better if you fix the setup